### PR TITLE
downgrade node (v12.x → v10.x)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,8 @@ WORKDIR /home/circleci
 RUN curl -L -o ./install-misspell.sh https://git.io/misspell
 RUN bash install-misspell.sh
 RUN sudo ln -s /home/circleci/bin/misspell /usr/local/bin/misspell
+
+# downgrade node (v12.x → v10.x)
+RUN wget https://nodejs.org/download/release/v10.16.2/node-v10.16.2-linux-x64.tar.xz
+RUN tar Jxfv node-v10.16.2-linux-x64.tar.xz
+RUN sudo cp node-v10.16.2-linux-x64/bin/node /usr/local/bin/


### PR DESCRIPTION
nodeのバージョン下げたprです！
🙏🙏 

理由：
node -v
v12.14.1
で
↓のようなエラーメッセージが出ていたので
```
Error: Missing binding /home/circleci/www/node_modules/node-sass/vendor/linux-x64-72/binding.node
Node Sass could not find a binding for your current environment: Linux 64-bit with Node.js 12.x
Found bindings for the following environments:
  - Linux 64-bit with Node.js 10.x
```

`node-sass`のバージョンを上げた場合は、ダウングレードの記載を削除する